### PR TITLE
Update to Ghidra 10.4 (new Help build system)

### DIFF
--- a/PatchDiffCorrelator/src/main/help/help/topics/patchdiffcorrelator/help.html
+++ b/PatchDiffCorrelator/src/main/help/help/topics/patchdiffcorrelator/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
Updated the plugin to build with the new Help build system. It now builds successfully for Ghidra 10.4.